### PR TITLE
Small module fixes

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -64,16 +64,16 @@ in {
     ];
 
     users.users = lib.optionalAttrs (cfg.user == "pterodactyl") {
-      wings = {
-        name = "wings";
+      pterodactyl = {
+        name = "pterodactyl";
         group = cfg.group;
         isSystemUser = true;
       };
     };
 
     users.groups = lib.optionalAttrs (cfg.group == "pterodactyl") {
-      wings = {
-        name = "wings";
+      pterodactyl = {
+        name = "pterodactyl";
       };
     };
 

--- a/module.nix
+++ b/module.nix
@@ -19,12 +19,12 @@ in {
     user = lib.mkOption {
       type = lib.types.str;
       description = lib.mdDoc "The user to run the Pterodactyl Wings daemon as";
-      default = "wings";
+      default = "pterodactyl";
     };
     group = lib.mkOption {
       type = lib.types.str;
       description = lib.mdDoc "The group to run the Pterodactyl Wings daemon as";
-      default = "wings";
+      default = "pterodactyl";
     };
     tokenFile = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
@@ -63,7 +63,7 @@ in {
       }
     ];
 
-    users.users = lib.optionalAttrs (cfg.user == "wings") {
+    users.users = lib.optionalAttrs (cfg.user == "pterodactyl") {
       wings = {
         name = "wings";
         group = cfg.group;
@@ -71,7 +71,7 @@ in {
       };
     };
 
-    users.groups = lib.optionalAttrs (cfg.group == "wings") {
+    users.groups = lib.optionalAttrs (cfg.group == "pterodactyl") {
       wings = {
         name = "wings";
       };
@@ -81,6 +81,7 @@ in {
     systemd.tmpfiles.rules = [
       "d /var/log/pterodactyl 0700 ${cfg.user} ${cfg.group}"
       "d /var/lib/pterodactyl 0700 ${cfg.user} ${cfg.group}"
+      "d /etc/pterodactyl 0700 ${cfg.user} ${cfg.group}"
     ];
 
     systemd.services.wings = {


### PR DESCRIPTION
Makes the default user be `pterodactyl` and ensures that `/etc/pterodactyl` exists and is owned by the user.